### PR TITLE
Smalls changes to make test easier

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+This file will automatically be included before EACH run.
+
+Use it to configure atoum or anything that needs to be done before EACH run.
+
+More information on documentation:
+[en] http://docs.atoum.org/en/latest/chapter3.html#configuration-files
+[fr] http://docs.atoum.org/fr/latest/lancement_des_tests.html#fichier-de-configuration
+*/
+
+use \mageekguy\atoum;
+
+$report = $script->addDefaultReport();
+
+$report->addField(new atoum\report\fields\runner\result\logo());
+$runner->addTestsFromDirectory('tests/Units');

--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+This file will automatically be included before EACH test if -bf/--bootstrap-file argument is not used.
+
+Use it to initialize the tested code, add autoloader, require mandatory file, or anything that needs to be done before EACH test.
+
+More information on documentation:
+[en] http://docs.atoum.org/en/latest/chapter3.html#bootstrap-file
+[fr] http://docs.atoum.org/fr/latest/lancement_des_tests.html#fichier-de-bootstrap
+*/
+require __DIR__ . '/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+language: php
+
+php:
+    - 5.5
+    - 5.6
+    - 7.0
+
+before_install:
+    - phpenv config-rm xdebug.ini
+
+before_script:
+    - composer self-update || true
+    - composer install --dev --prefer-dist
+
+script:
+    - vendor/bin/atoum

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,17 @@
             "Rezzza\\CommandBus\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Rezzza\\CommandBus\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.1.x-dev"
         }
+    },
+    "require-dev": {
+        "atoum/atoum": "^2.5"
     }
 }

--- a/examples/direct.php
+++ b/examples/direct.php
@@ -11,8 +11,6 @@ $handlerLocator = new CommandBus\Infra\Handler\MemoryHandlerLocator();
 $handlerLocator->addHandler('FooCommand', function($command) {
     echo sprintf('Launch command [%s] with id: %s', get_class($command), $command->getId());
 });
-
-$eventDispatcher = new Symfony\Component\EventDispatcher\EventDispatcher();
-
-$bus = new CommandBus\Infra\Provider\Direct\DirectBus($handlerLocator, $eventDispatcher);
+$handlerMethodNameResolver = new CommandBus\Domain\Handler\MethodResolver\ClassNameAsMethodWithoutSuffix;
+$bus = new CommandBus\Infra\Provider\Direct\DirectBus($handlerLocator, $handlerMethodNameResolver);
 $bus->handle($command);

--- a/examples/redis_producer.php
+++ b/examples/redis_producer.php
@@ -12,9 +12,8 @@ $redis = new \Redis();
 $redis->connect('127.0.0.1');
 
 $redisKeyGenerator = new CommandBus\Infra\Provider\Redis\RedisKeyGenerator();
-$eventDispatcher   = new Symfony\Component\EventDispatcher\EventDispatcher();
 $serializer        = new CommandBus\Infra\Serializer\NativeSerializer();
-$bus               = new CommandBus\Infra\Provider\Redis\RedisBus($redis, $redisKeyGenerator, $serializer, $eventDispatcher, new Logger());
+$bus               = new CommandBus\Infra\Provider\Redis\RedisBus($redis, $redisKeyGenerator, $serializer);
 
 for ($j = 0; $j < $i; $j++) {
     $bus->handle(new FooCommand(uniqid()));

--- a/examples/redis_worker.php
+++ b/examples/redis_worker.php
@@ -22,11 +22,12 @@ $redis->connect('127.0.0.1');
 $redisKeyGenerator = new CommandBus\Infra\Provider\Redis\RedisKeyGenerator();
 $serializer        = new CommandBus\Infra\Serializer\NativeSerializer();
 
-$redisBus = new CommandBus\Infra\Provider\Redis\RedisBus($redis, $redisKeyGenerator, $serializer, $eventDispatcher, $logger);
+$redisBus = new CommandBus\Infra\Provider\Redis\RedisBus($redis, $redisKeyGenerator, $serializer);
 
 // direct bus and its handlers.
 $handlerLocator = new CommandBus\Infra\Handler\MemoryHandlerLocator();
-$directBus      = new CommandBus\Infra\Provider\Direct\DirectBus($handlerLocator, $eventDispatcher, $logger);
+$handlerMethodNameResolver = new CommandBus\Domain\Handler\MethodResolver\ClassNameAsMethodWithoutSuffix;
+$directBus      = new CommandBus\Infra\Provider\Direct\DirectBus($handlerLocator, $handlerMethodNameResolver);
 
 // fail strategy, if command fail, it'll retry 10 times in a retry queue then go to a failed queue..
 $failStrategy = new CommandBus\Domain\Consumer\FailStrategy\RetryThenFailStrategy($redisBus, 10, $logger);
@@ -45,10 +46,12 @@ $handlerLocator->addHandler('FooCommand', function ($command) {
 $handlerLocator->addHandler('Rezzza\CommandBus\Domain\Command\RetryCommand', new CommandBus\Domain\Handler\RetryHandler($directBus, $logger));
 $handlerLocator->addHandler('Rezzza\CommandBus\Domain\Command\FailedCommand', new CommandBus\Domain\Handler\FailedHandler($directBus, $logger));
 
+$loggerBus = new Rezzza\CommandBus\Domain\LoggerBus($logger, $directBus);
+
 // consumer
 $consumer = new CommandBus\Domain\Consumer\Consumer(
     new CommandBus\Infra\Provider\Redis\RedisConsumerProvider($redis, $redisKeyGenerator, $serializer),
-    $directBus,
+    $loggerBus,
     $failStrategy,
     $eventDispatcher
 );

--- a/examples/tools/Logger.php
+++ b/examples/tools/Logger.php
@@ -4,6 +4,6 @@ class Logger extends Psr\Log\AbstractLogger implements Psr\Log\LoggerInterface
 {
     public function log($level, $message, array $context = array())
     {
-        echo chr(10).sprintf('Log lvl [%s]: %s', $level, $message);
+        echo chr(10).sprintf('Log lvl [%s]: %s : %s', $level, $message, var_export($context, true)).chr(10);
     }
 }

--- a/src/Domain/CommandBusInterface.php
+++ b/src/Domain/CommandBusInterface.php
@@ -7,5 +7,5 @@ interface CommandBusInterface
     CONST PRIORITY_HIGH = 10;
     CONST PRIORITY_LOW  = 0;
 
-    public function handle(CommandInterface $command, $prority = null);
+    public function handle(CommandInterface $command, $priority = null);
 }

--- a/src/Domain/CommandBusInterface.php
+++ b/src/Domain/CommandBusInterface.php
@@ -7,5 +7,17 @@ interface CommandBusInterface
     CONST PRIORITY_HIGH = 10;
     CONST PRIORITY_LOW  = 0;
 
+    /** The bus will delegate to another process the handle of the command */
+    CONST ASYNC_HANDLE_TYPE = 'async';
+    /** The bus will handle itself the command execution */
+    CONST SYNC_HANDLE_TYPE = 'sync';
+
     public function handle(CommandInterface $command, $priority = null);
+
+    /**
+     * Should return CommandBusInterface::ASYNC_HANDLE_TYPE or CommandBusInterface::SYNC_HANDLE_TYPE
+     *
+     * @return string
+     */
+    public function getHandleType();
 }

--- a/src/Domain/Consumer/Consumer.php
+++ b/src/Domain/Consumer/Consumer.php
@@ -57,7 +57,10 @@ class Consumer
                 $response = new Response($command, Response::FAILED, $e);
             }
 
-            $this->eventDispatcher->dispatch(Event\Events::ON_CONSUMER_RESPONSE, new Event\OnConsumerResponseEvent($response));
+            $this->eventDispatcher->dispatch(
+                Event\Events::ON_CONSUMER_RESPONSE,
+                new Event\OnConsumerResponseEvent($this->commandBus->getHandleType(), $response)
+            );
 
             return $response;
         }

--- a/src/Domain/Consumer/Consumer.php
+++ b/src/Domain/Consumer/Consumer.php
@@ -3,7 +3,7 @@
 namespace Rezzza\CommandBus\Domain\Consumer;
 
 use Rezzza\CommandBus\Domain\Consumer\FailStrategy\FailStrategyInterface;
-use Rezzza\CommandBus\Domain\DirectCommandBusInterface;
+use Rezzza\CommandBus\Domain\CommandBusInterface;
 use Rezzza\CommandBus\Domain\Event;
 use Rezzza\CommandBus\Domain\Exception\CommandHandlerFailedException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -17,12 +17,16 @@ class Consumer
 
     /**
      * @param ProviderInterface         $provider     provider
-     * @param DirectCommandBusInterface $commandBus   commandBus
+     * @param CommandBusInterface $commandBus   commandBus
      * @param FailStrategyInterface     $failStrategy failStrategy
      * @param EventDispatcherInterface  $eventDispatcher eventDispatcher
      */
-    public function __construct(ProviderInterface $provider, DirectCommandBusInterface $commandBus, FailStrategyInterface $failStrategy, EventDispatcherInterface $eventDispatcher)
+    public function __construct(ProviderInterface $provider, CommandBusInterface $commandBus, FailStrategyInterface $failStrategy, EventDispatcherInterface $eventDispatcher)
     {
+        if (CommandBusInterface::SYNC_HANDLE_TYPE !== $commandBus->getHandleType()) {
+            throw new \RuntimeException('Consume should be powered by a synchronous handle type');
+        }
+
         $this->provider        = $provider;
         $this->commandBus      = $commandBus;
         $this->failStrategy    = $failStrategy;

--- a/src/Domain/DirectCommandBusInterface.php
+++ b/src/Domain/DirectCommandBusInterface.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Rezzza\CommandBus\Domain;
-
-interface DirectCommandBusInterface extends CommandBusInterface
-{
-}

--- a/src/Domain/Event/OnConsumerResponseEvent.php
+++ b/src/Domain/Event/OnConsumerResponseEvent.php
@@ -13,12 +13,22 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class OnConsumerResponseEvent extends Event
 {
+    private $handleType;
+
+    private $response;
+
     /**
      * @param Response $response response
      */
-    public function __construct(Response $response)
+    public function __construct($handleType, Response $response)
     {
+        $this->handleType = $handleType;
         $this->response = $response;
+    }
+
+    public function getHandleType()
+    {
+        return $this->handleType;
     }
 
     /**

--- a/src/Domain/Event/OnDirectResponseEvent.php
+++ b/src/Domain/Event/OnDirectResponseEvent.php
@@ -13,12 +13,23 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class OnDirectResponseEvent extends Event
 {
+    private $handleType;
+
+    private $response;
+
     /**
+     * @param string $handleType
      * @param Response $response response
      */
-    public function __construct(Response $response)
+    public function __construct($handleType, Response $response)
     {
+        $this->handleType = $handleType;
         $this->response = $response;
+    }
+
+    public function getHandleType()
+    {
+        return $this->handleType;
     }
 
     /**

--- a/src/Domain/Event/PreHandleCommandEvent.php
+++ b/src/Domain/Event/PreHandleCommandEvent.php
@@ -2,7 +2,6 @@
 
 namespace Rezzza\CommandBus\Domain\Event;
 
-use Rezzza\CommandBus\Domain\CommandBusInterface;
 use Rezzza\CommandBus\Domain\CommandInterface;
 use Symfony\Component\EventDispatcher\Event;
 
@@ -14,15 +13,19 @@ use Symfony\Component\EventDispatcher\Event;
  */
 class PreHandleCommandEvent extends Event
 {
-    public function __construct(CommandBusInterface $bus, CommandInterface $command)
+    private $handleType;
+
+    private $command;
+
+    public function __construct($handleType, CommandInterface $command)
     {
-        $this->bus     = $bus;
+        $this->handleType = $handleType;
         $this->command = $command;
     }
 
-    public function getBus()
+    public function getHandleType()
     {
-        return $this->bus;
+        return $this->handleType;
     }
 
     public function getCommand()

--- a/src/Domain/EventDispatcherBus.php
+++ b/src/Domain/EventDispatcherBus.php
@@ -26,17 +26,22 @@ class EventDispatcherBus implements CommandBusInterface
     public function handle(CommandInterface $command, $priority = null)
     {
         try {
-            $this->eventDispatcher->dispatch(Event\Events::PRE_HANDLE_COMMAND, new Event\PreHandleCommandEvent($this, $command));
+            $this->eventDispatcher->dispatch(
+                Event\Events::PRE_HANDLE_COMMAND,
+                new Event\PreHandleCommandEvent($this->getHandleType(), $command)
+            );
 
             $this->delegateCommandBus->handle($command, $priority);
 
-            $this->eventDispatcher->dispatch(Event\Events::ON_DIRECT_RESPONSE, new Event\OnDirectResponseEvent(new Response(
-                $command, Response::SUCCESS
-            )));
+            $this->eventDispatcher->dispatch(
+                Event\Events::ON_DIRECT_RESPONSE,
+                new Event\OnDirectResponseEvent($this->getHandleType(), new Response($command, Response::SUCCESS))
+            );
         } catch (\Exception $e) {
-            $this->eventDispatcher->dispatch(Event\Events::ON_DIRECT_RESPONSE, new Event\OnDirectResponseEvent(new Response(
-                $command, Response::FAILED, $e
-            )));
+            $this->eventDispatcher->dispatch(
+                Event\Events::ON_DIRECT_RESPONSE,
+                new Event\OnDirectResponseEvent($this->getHandleType(), new Response($command, Response::FAILED, $e))
+            );
 
             throw $e;
         }

--- a/src/Domain/EventDispatcherBus.php
+++ b/src/Domain/EventDispatcherBus.php
@@ -6,7 +6,7 @@ use Rezzza\CommandBus\Domain\Consumer\Response;
 use Rezzza\CommandBus\Domain\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class EventDispatcherBus implements DirectCommandBusInterface
+class EventDispatcherBus implements CommandBusInterface
 {
     private $eventDispatcher;
 
@@ -16,6 +16,11 @@ class EventDispatcherBus implements DirectCommandBusInterface
     {
         $this->eventDispatcher = $eventDispatcher;
         $this->delegateCommandBus = $delegateCommandBus;
+    }
+
+    public function getHandleType()
+    {
+        return $this->delegateCommandBus->getHandleType();
     }
 
     public function handle(CommandInterface $command, $priority = null)

--- a/src/Domain/EventDispatcherBus.php
+++ b/src/Domain/EventDispatcherBus.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rezzza\CommandBus\Domain;
+
+use Rezzza\CommandBus\Domain\Consumer\Response;
+use Rezzza\CommandBus\Domain\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class EventDispatcherBus implements CommandBusInterface
+{
+    private $eventDispatcher;
+
+    private $delegateCommandBus;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, CommandBusInterface $delegateCommandBus)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->delegateCommandBus = $delegateCommandBus;
+    }
+
+    public function handle(CommandInterface $command, $priority = null)
+    {
+        try {
+            $this->eventDispatcher->dispatch(Event\Events::PRE_HANDLE_COMMAND, new Event\PreHandleCommandEvent($this, $command));
+
+            $this->delegateCommandBus->handle($command, $priority);
+
+            $this->eventDispatcher->dispatch(Event\Events::ON_DIRECT_RESPONSE, new Event\OnDirectResponseEvent(new Response(
+                $command, Response::SUCCESS
+            )));
+        } catch (\Exception $e) {
+            $this->eventDispatcher->dispatch(Event\Events::ON_DIRECT_RESPONSE, new Event\OnDirectResponseEvent(new Response(
+                $command, Response::FAILED, $e
+            )));
+
+            throw $e;
+        }
+    }
+}

--- a/src/Domain/EventDispatcherBus.php
+++ b/src/Domain/EventDispatcherBus.php
@@ -6,7 +6,7 @@ use Rezzza\CommandBus\Domain\Consumer\Response;
 use Rezzza\CommandBus\Domain\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class EventDispatcherBus implements CommandBusInterface
+class EventDispatcherBus implements DirectCommandBusInterface
 {
     private $eventDispatcher;
 

--- a/src/Domain/Handler/FailedHandler.php
+++ b/src/Domain/Handler/FailedHandler.php
@@ -4,7 +4,7 @@ namespace Rezzza\CommandBus\Domain\Handler;
 
 use Psr\Log\LoggerInterface;
 use Rezzza\CommandBus\Domain\Command\FailedCommand;
-use Rezzza\CommandBus\Domain\DirectCommandBusInterface;
+use Rezzza\CommandBus\Domain\CommandBusInterface;
 use Rezzza\CommandBus\Domain\Exception\CommandHandlerFailedException;
 
 class FailedHandler
@@ -12,7 +12,7 @@ class FailedHandler
     private $commandBus;
     private $logger;
 
-    public function __construct(DirectCommandBusInterface $commandBus, LoggerInterface $logger = null)
+    public function __construct(CommandBusInterface $commandBus, LoggerInterface $logger = null)
     {
         $this->commandBus   = $commandBus;
         $this->logger       = $logger;

--- a/src/Domain/Handler/HandlerMethodResolverInterface.php
+++ b/src/Domain/Handler/HandlerMethodResolverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rezzza\CommandBus\Domain\Handler;
+
+use Rezzza\CommandBus\Domain\CommandInterface;
+
+interface HandlerMethodResolverInterface
+{
+    public function resolveMethodName(CommandInterface $command, $commandHandler);
+}

--- a/src/Domain/Handler/MethodResolver/ClassNameAsMethodWithoutSuffix.php
+++ b/src/Domain/Handler/MethodResolver/ClassNameAsMethodWithoutSuffix.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rezzza\CommandBus\Domain\Handler\MethodResolver;
+
+use Rezzza\CommandBus\Domain\Handler\HandlerMethodResolverInterface;
+use Rezzza\CommandBus\Domain\CommandInterface;
+
+/**
+ * Command \Acme\Foo\Bar\DoActionCommand return doAction.
+ */
+class ClassNameAsMethodWithoutSuffix implements HandlerMethodResolverInterface
+{
+    public function resolveMethodName(CommandInterface $command, $commandHandler)
+    {
+        $parts = explode("\\", get_class($command));
+
+        return str_replace("Command", "", lcfirst(end($parts)));
+    }
+}

--- a/src/Domain/Handler/RetryHandler.php
+++ b/src/Domain/Handler/RetryHandler.php
@@ -3,7 +3,7 @@
 namespace Rezzza\CommandBus\Domain\Handler;
 
 use Psr\Log\LoggerInterface;
-use Rezzza\CommandBus\Domain\DirectCommandBusInterface;
+use Rezzza\CommandBus\Domain\CommandBusInterface;
 use Rezzza\CommandBus\Domain\Command\RetryCommand;
 use Rezzza\CommandBus\Domain\Exception\CommandHandlerFailedException;
 
@@ -12,7 +12,7 @@ class RetryHandler
     private $commandBus;
     private $logger;
 
-    public function __construct(DirectCommandBusInterface $commandBus, LoggerInterface $logger = null)
+    public function __construct(CommandBusInterface $commandBus, LoggerInterface $logger = null)
     {
         $this->commandBus   = $commandBus;
         $this->logger       = $logger;

--- a/src/Domain/LoggerBus.php
+++ b/src/Domain/LoggerBus.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rezzza\CommandBus\Domain;
+
+use Psr\Log\LoggerInterface;
+
+class LoggerBus implements CommandBusInterface
+{
+    private $logger;
+
+    private $delegateCommandBus;
+
+    public function __construct(LoggerBus $logger, CommandBusInterface $delegateCommandBus)
+    {
+        $this->logger = $logger;
+        $this->delegateCommandBus = $delegateCommandBus;
+    }
+
+    public function handle(CommandInterface $command, $priority = null)
+    {
+        try {
+            $this->logger->notice(
+                'CommandBus handle command',
+                [
+                    'bus' => get_class($this->delegateCommandBus),
+                    'command' => serialize($command)
+                ]
+            );
+            $this->delegateCommandBus->handle($command, $priority);
+        } catch (\Exception $e) {
+            $this->logger->error(
+                'CommandBus failed to handle command',
+                [
+                    'bus' => get_class($this->delegateCommandBus),
+                    'command' => serialize($command),
+                    'exception_message' => $e->getMessage()
+                ]
+            );
+
+            throw $e;
+        }
+    }
+}

--- a/src/Domain/LoggerBus.php
+++ b/src/Domain/LoggerBus.php
@@ -4,7 +4,7 @@ namespace Rezzza\CommandBus\Domain;
 
 use Psr\Log\LoggerInterface;
 
-class LoggerBus implements DirectCommandBusInterface
+class LoggerBus implements CommandBusInterface
 {
     private $logger;
 
@@ -14,6 +14,11 @@ class LoggerBus implements DirectCommandBusInterface
     {
         $this->logger = $logger;
         $this->delegateCommandBus = $delegateCommandBus;
+    }
+
+    public function getHandleType()
+    {
+        return $this->delegateCommandBus->getHandleType();
     }
 
     public function handle(CommandInterface $command, $priority = null)

--- a/src/Domain/LoggerBus.php
+++ b/src/Domain/LoggerBus.php
@@ -4,13 +4,13 @@ namespace Rezzza\CommandBus\Domain;
 
 use Psr\Log\LoggerInterface;
 
-class LoggerBus implements CommandBusInterface
+class LoggerBus implements DirectCommandBusInterface
 {
     private $logger;
 
     private $delegateCommandBus;
 
-    public function __construct(LoggerBus $logger, CommandBusInterface $delegateCommandBus)
+    public function __construct(LoggerInterface $logger, CommandBusInterface $delegateCommandBus)
     {
         $this->logger = $logger;
         $this->delegateCommandBus = $delegateCommandBus;

--- a/src/Infra/Provider/Direct/DirectBus.php
+++ b/src/Infra/Provider/Direct/DirectBus.php
@@ -3,9 +3,7 @@
 namespace Rezzza\CommandBus\Infra\Provider\Direct;
 
 use Rezzza\CommandBus\Domain\CommandInterface;
-use Rezzza\CommandBus\Domain\Consumer\Response;
 use Rezzza\CommandBus\Domain\DirectCommandBusInterface;
-use Rezzza\CommandBus\Domain\Event;
 use Rezzza\CommandBus\Domain\Handler\CommandHandlerLocatorInterface;
 use Rezzza\CommandBus\Domain\Handler\HandlerDefinition;
 use Rezzza\CommandBus\Domain\Handler\HandlerMethodResolverInterface;
@@ -14,58 +12,41 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class DirectBus implements DirectCommandBusInterface
 {
     private $locator;
-    private $eventDispatcher;
     private $methodResolver;
 
     /**
-     * @param CommandHandlerLocatorInterface $locator         locator
-     * @param EventDispatcherInterface       $eventDispatcher eventDispatcher
+     * @param CommandHandlerLocatorInterface $locator
      * @param HandlerMethodResolverInterface $methodResolver
      */
-    public function __construct(CommandHandlerLocatorInterface $locator, EventDispatcherInterface $eventDispatcher, HandlerMethodResolverInterface $methodResolver)
+    public function __construct(CommandHandlerLocatorInterface $locator, HandlerMethodResolverInterface $methodResolver)
     {
         $this->locator         = $locator;
-        $this->eventDispatcher = $eventDispatcher;
         $this->methodResolver = $methodResolver;
     }
 
     public function handle(CommandInterface $command, $priority = null)
     {
-        try {
-            $this->eventDispatcher->dispatch(Event\Events::PRE_HANDLE_COMMAND, new Event\PreHandleCommandEvent($this, $command));
+        $handler = $this->locator->getCommandHandler($command);
 
-            $handler = $this->locator->getCommandHandler($command);
-
-            if (is_callable($handler)) {
-                $handler($command);
-            } elseif (is_object($handler)) {
-                $method = null;
-                if ($handler instanceof HandlerDefinition) {
-                    $method  = $handler->getMethod();
-                    $handler = $handler->getObject();
-                }
-
-                if (null === $method) {
-                    $method  = $this->methodResolver->resolveMethodName($command, $handler);
-                }
-
-                if (!method_exists($handler, $method)) {
-                    throw new \RuntimeException(sprintf("Service %s has no method %s to handle command.", get_class($handler), $method));
-                }
-                $handler->$method($command);
-
-                $this->eventDispatcher->dispatch(Event\Events::ON_DIRECT_RESPONSE, new Event\OnDirectResponseEvent(new Response(
-                    $command, Response::SUCCESS
-                )));
-            } else {
-                throw new \LogicException(sprintf('Handler locator return a not object|callable handler, type is %s', gettype($handler)));
+        if (is_callable($handler)) {
+            $handler($command);
+        } elseif (is_object($handler)) {
+            $method = null;
+            if ($handler instanceof HandlerDefinition) {
+                $method  = $handler->getMethod();
+                $handler = $handler->getObject();
             }
-        } catch (\Exception $e) {
-            $this->eventDispatcher->dispatch(Event\Events::ON_DIRECT_RESPONSE, new Event\OnDirectResponseEvent(new Response(
-                $command, Response::FAILED, $e
-            )));
 
-            throw $e;
+            if (null === $method) {
+                $method  = $this->methodResolver->resolveMethodName($command, $handler);
+            }
+
+            if (!method_exists($handler, $method)) {
+                throw new \RuntimeException(sprintf("Service %s has no method %s to handle command.", get_class($handler), $method));
+            }
+            $handler->$method($command);
+        } else {
+            throw new \LogicException(sprintf('Handler locator return a not object|callable handler, type is %s', gettype($handler)));
         }
     }
 }

--- a/src/Infra/Provider/Direct/DirectBus.php
+++ b/src/Infra/Provider/Direct/DirectBus.php
@@ -3,13 +3,13 @@
 namespace Rezzza\CommandBus\Infra\Provider\Direct;
 
 use Rezzza\CommandBus\Domain\CommandInterface;
-use Rezzza\CommandBus\Domain\DirectCommandBusInterface;
+use Rezzza\CommandBus\Domain\CommandBusInterface;
 use Rezzza\CommandBus\Domain\Handler\CommandHandlerLocatorInterface;
 use Rezzza\CommandBus\Domain\Handler\HandlerDefinition;
 use Rezzza\CommandBus\Domain\Handler\HandlerMethodResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class DirectBus implements DirectCommandBusInterface
+class DirectBus implements CommandBusInterface
 {
     private $locator;
     private $methodResolver;
@@ -22,6 +22,11 @@ class DirectBus implements DirectCommandBusInterface
     {
         $this->locator         = $locator;
         $this->methodResolver = $methodResolver;
+    }
+
+    public function getHandleType()
+    {
+        return CommandBusInterface::SYNC_HANDLE_TYPE;
     }
 
     public function handle(CommandInterface $command, $priority = null)

--- a/src/Infra/Provider/Redis/RedisBus.php
+++ b/src/Infra/Provider/Redis/RedisBus.php
@@ -35,6 +35,11 @@ class RedisBus implements CommandBusInterface
         $this->serializer        = $serializer;
     }
 
+    public function getHandleType()
+    {
+        return CommandBusInterface::ASYNC_HANDLE_TYPE;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Infra/Provider/Redis/RedisBus.php
+++ b/src/Infra/Provider/Redis/RedisBus.php
@@ -2,7 +2,6 @@
 
 namespace Rezzza\CommandBus\Infra\Provider\Redis;
 
-use Psr\Log\LoggerInterface;
 use Rezzza\CommandBus\Domain\CommandBusInterface;
 use Rezzza\CommandBus\Domain\CommandInterface;
 use Rezzza\CommandBus\Domain\Event;
@@ -32,24 +31,17 @@ class RedisBus implements CommandBusInterface
     protected $eventDispatcher;
 
     /**
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
      * @param \Redis                     $client          client
      * @param RedisKeyGeneratorInterface $keyGenerator    keyGenerator
      * @param CommandSerializerInterface $serializer      serializer
      * @param EventDispatcherInterface   $eventDispatcher eventDispatcher
-     * @param LoggerInterface            $logger          logger
      */
-    public function __construct(\Redis $client, RedisKeyGeneratorInterface $keyGenerator, CommandSerializerInterface $serializer, EventDispatcherInterface $eventDispatcher, LoggerInterface $logger = null)
+    public function __construct(\Redis $client, RedisKeyGeneratorInterface $keyGenerator, CommandSerializerInterface $serializer, EventDispatcherInterface $eventDispatcher)
     {
         $this->client            = $client;
         $this->keyGenerator      = $keyGenerator;
         $this->serializer        = $serializer;
         $this->eventDispatcher   = $eventDispatcher;
-        $this->logger            = $logger;
     }
 
     /**
@@ -60,10 +52,6 @@ class RedisBus implements CommandBusInterface
         $this->eventDispatcher->dispatch(Event\Events::PRE_HANDLE_COMMAND, new Event\PreHandleCommandEvent($this, $command));
 
         $serializedCommand = $this->serializer->serialize($command);
-
-        if ($this->logger) {
-            $this->logger->info(sprintf('[RedisCommandBus] Add command [%s] with content [%s] to the queue', get_class($command), $serializedCommand));
-        }
 
         $redisMethod = ($priority >= CommandBusInterface::PRIORITY_HIGH) ? 'lpush' : 'rpush';
 

--- a/src/Infra/Provider/Redis/RedisBus.php
+++ b/src/Infra/Provider/Redis/RedisBus.php
@@ -4,9 +4,7 @@ namespace Rezzza\CommandBus\Infra\Provider\Redis;
 
 use Rezzza\CommandBus\Domain\CommandBusInterface;
 use Rezzza\CommandBus\Domain\CommandInterface;
-use Rezzza\CommandBus\Domain\Event;
 use Rezzza\CommandBus\Domain\Serializer\CommandSerializerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class RedisBus implements CommandBusInterface
 {
@@ -26,22 +24,15 @@ class RedisBus implements CommandBusInterface
     protected $serializer;
 
     /**
-     * @var EventDispatcherInterface
-     */
-    protected $eventDispatcher;
-
-    /**
      * @param \Redis                     $client          client
      * @param RedisKeyGeneratorInterface $keyGenerator    keyGenerator
      * @param CommandSerializerInterface $serializer      serializer
-     * @param EventDispatcherInterface   $eventDispatcher eventDispatcher
      */
-    public function __construct(\Redis $client, RedisKeyGeneratorInterface $keyGenerator, CommandSerializerInterface $serializer, EventDispatcherInterface $eventDispatcher)
+    public function __construct(\Redis $client, RedisKeyGeneratorInterface $keyGenerator, CommandSerializerInterface $serializer)
     {
         $this->client            = $client;
         $this->keyGenerator      = $keyGenerator;
         $this->serializer        = $serializer;
-        $this->eventDispatcher   = $eventDispatcher;
     }
 
     /**
@@ -49,8 +40,6 @@ class RedisBus implements CommandBusInterface
      */
     public function handle(CommandInterface $command, $priority = null)
     {
-        $this->eventDispatcher->dispatch(Event\Events::PRE_HANDLE_COMMAND, new Event\PreHandleCommandEvent($this, $command));
-
         $serializedCommand = $this->serializer->serialize($command);
 
         $redisMethod = ($priority >= CommandBusInterface::PRIORITY_HIGH) ? 'lpush' : 'rpush';

--- a/tests/Fixtures/Command/SendWelcomeEmailCommand.php
+++ b/tests/Fixtures/Command/SendWelcomeEmailCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Rezzza\CommandBus\Tests\Fixtures\Command;
+
+use Rezzza\CommandBus\Domain\CommandInterface;
+
+class SendWelcomeEmailCommand implements CommandInterface
+{
+}

--- a/tests/Fixtures/UserService.php
+++ b/tests/Fixtures/UserService.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rezzza\CommandBus\Tests\Fixtures;
+
+class UserService
+{
+    public function sendWelcomeEmail($command)
+    {
+    }
+}

--- a/tests/Units/Domain/Handler/MethodResolver/ClassNameAsMethodWithoutSuffix.php
+++ b/tests/Units/Domain/Handler/MethodResolver/ClassNameAsMethodWithoutSuffix.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rezzza\CommandBus\Tests\Units\Domain\Handler\MethodResolver;
+
+use mageekguy\atoum;
+
+class ClassNameAsMethodWithoutSuffix extends atoum\test
+{
+    public function test_it_should_resolve_the_method_name_from_command_name()
+    {
+        $this
+            ->given(
+                $sut = $this->newTestedInstance,
+                $command = new \Rezzza\CommandBus\Tests\Fixtures\Command\SendWelcomeEmailCommand,
+                $handler = new \mock\StdClass
+            )
+            ->when(
+                $methodName = $sut->resolveMethodName($command, $handler)
+            )
+            ->then
+                ->phpString($methodName)->isEqualTo('sendWelcomeEmail')
+        ;
+    }
+}

--- a/tests/Units/Infra/Provider/Direct/DirectBus.php
+++ b/tests/Units/Infra/Provider/Direct/DirectBus.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Rezzza\CommandBus\Tests\Units\Infra\Provider\Direct;
+
+use mageekguy\atoum;
+
+class DirectBus extends atoum\test
+{
+    public function test_object_handler_should_be_executed_through_the_method_name_resolved()
+    {
+        $this
+            ->given(
+                $command = new \Rezzza\CommandBus\Tests\Fixtures\Command\SendWelcomeEmailCommand,
+                $handler = new \mock\Rezzza\CommandBus\Tests\Fixtures\UserService,
+                $this->calling($handler)->sendWelcomeEmail = true
+            )
+            ->and(
+                $locator = new \mock\Rezzza\CommandBus\Domain\Handler\CommandHandlerLocatorInterface,
+                $this->calling($locator)->getCommandHandler = $handler,
+                $methodResolver = new \mock\Rezzza\CommandBus\Domain\Handler\HandlerMethodResolverInterface,
+                $this->calling($methodResolver)->resolveMethodName = 'sendWelcomeEmail',
+                $sut = $this->newTestedInstance($locator, $methodResolver)
+            )
+            ->when(
+                $sut->handle($command)
+            )
+            ->then
+                ->mock($handler)
+                    ->call('sendWelcomeEmail')
+                    ->withArguments($command)
+                    ->once()
+        ;
+    }
+
+    public function test_missing_resolved_method_name_on_handler_should_lead_to_exception()
+    {
+        $this
+            ->given(
+                $command = new \Rezzza\CommandBus\Tests\Fixtures\Command\SendWelcomeEmailCommand,
+                $handler = new \mock\Rezzza\CommandBus\Tests\Fixtures\UserService
+            )
+            ->and(
+                $locator = new \mock\Rezzza\CommandBus\Domain\Handler\CommandHandlerLocatorInterface,
+                $this->calling($locator)->getCommandHandler = $handler,
+                $methodResolver = new \mock\Rezzza\CommandBus\Domain\Handler\HandlerMethodResolverInterface,
+                $this->calling($methodResolver)->resolveMethodName = 'tututu',
+                $sut = $this->newTestedInstance($locator, $methodResolver)
+            )
+            ->exception(function () use ($sut, $command) {
+                $sut->handle($command);
+            })
+                ->hasMessage('Service mock\Rezzza\CommandBus\Tests\Fixtures\UserService has no method tututu to handle command.')
+            ->then
+                ->mock($handler)
+                    ->wasNotCalled()
+        ;
+    }
+
+    public function test_no_handler_located_should_lead_to_exception()
+    {
+        $this
+            ->given(
+                $locator = new \mock\Rezzza\CommandBus\Domain\Handler\CommandHandlerLocatorInterface,
+                $this->calling($locator)->getCommandHandler = null,
+                $methodResolver = new \mock\Rezzza\CommandBus\Domain\Handler\HandlerMethodResolverInterface,
+                $sut = $this->newTestedInstance($locator, $methodResolver)
+            )
+            ->exception(function () use ($sut) {
+                $sut->handle(new \Rezzza\CommandBus\Tests\Fixtures\Command\SendWelcomeEmailCommand);
+            })
+                ->hasMessage('Handler locator return a not object|callable handler, type is NULL')
+        ;
+    }
+}


### PR DESCRIPTION
BC breaks:
- `RedisBus` and `DirectBus` constructor signature
- Remove `DirectCommandBusInterface`
- Add `CommandBusInterface::getHandleType`
- Remove injected `$bus` from `PreHandleCommandEvent`

So we will bump to 2.0 after this merge.
