### PR TITLE
Use Symfony normalizer to improve loggerBus

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": ">=5.5.0",
         "psr/log": "~1.0",
-        "symfony/event-dispatcher": "~2.5|~3.0"
+        "symfony/event-dispatcher": "~2.5|~3.0",
+        "symfony/serializer": "~2.5|~3.0"
     },
     "autoload": {
         "psr-4": {

--- a/examples/redis_worker.php
+++ b/examples/redis_worker.php
@@ -46,7 +46,13 @@ $handlerLocator->addHandler('FooCommand', function ($command) {
 $handlerLocator->addHandler('Rezzza\CommandBus\Domain\Command\RetryCommand', new CommandBus\Domain\Handler\RetryHandler($directBus, $logger));
 $handlerLocator->addHandler('Rezzza\CommandBus\Domain\Command\FailedCommand', new CommandBus\Domain\Handler\FailedHandler($directBus, $logger));
 
-$loggerBus = new Rezzza\CommandBus\Domain\LoggerBus($logger, $directBus, $serializer);
+$loggerBus = new Rezzza\CommandBus\Domain\LoggerBus(
+    $logger,
+    $directBus,
+    new \Symfony\Component\Serializer\Serializer([
+        new \Symfony\Component\Serializer\Normalizer\PropertyNormalizer
+    ])
+);
 
 // consumer
 $consumer = new CommandBus\Domain\Consumer\Consumer(

--- a/src/Domain/LoggerBus.php
+++ b/src/Domain/LoggerBus.php
@@ -3,7 +3,7 @@
 namespace Rezzza\CommandBus\Domain;
 
 use Psr\Log\LoggerInterface;
-use Rezzza\CommandBus\Domain\Serializer\CommandSerializerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class LoggerBus implements CommandBusInterface
 {
@@ -16,11 +16,11 @@ class LoggerBus implements CommandBusInterface
     public function __construct(
         LoggerInterface $logger,
         CommandBusInterface $delegateCommandBus,
-        CommandSerializerInterface $commandSerializer
+        NormalizerInterface $normalizer
     ) {
         $this->logger = $logger;
         $this->delegateCommandBus = $delegateCommandBus;
-        $this->commandSerializer = $commandSerializer;
+        $this->normalizer = $normalizer;
     }
 
     public function getHandleType()
@@ -32,21 +32,21 @@ class LoggerBus implements CommandBusInterface
     {
         try {
             $this->logger->notice(
-                'CommandBus handle command',
+                sprintf('CommandBus handle command %s', get_class($command)),
                 [
                     'bus' => get_class($this->delegateCommandBus),
                     'handle_type' => $this->getHandleType(),
-                    'command' => $this->commandSerializer->serialize($command)
+                    'command' => $this->normalizer->normalize($command),
                 ]
             );
             $this->delegateCommandBus->handle($command, $priority);
         } catch (\Exception $e) {
             $this->logger->error(
-                'CommandBus failed to handle command',
+                sprintf('CommandBus failed to handle command %s', get_class($command)),
                 [
                     'bus' => get_class($this->delegateCommandBus),
                     'handle_type' => $this->getHandleType(),
-                    'command' => $this->commandSerializer->serialize($command),
+                    'command' => $this->normalizer->normalize($command),
                     'exception_message' => $e->getMessage()
                 ]
             );


### PR DESCRIPTION
Currently it is very difficult to read log. In fact, we don't want to serialize command, only normalize them.
